### PR TITLE
Add sorting based on departure_year

### DIFF
--- a/content/authors/p_eetu-reijonen/_index.md
+++ b/content/authors/p_eetu-reijonen/_index.md
@@ -51,6 +51,7 @@ user_groups:
 - Previous Members
 
 next_affiliation: Aalto University
+departure_year: 2024
 ---
 
 I'm a research assistant and a bachelor's student in mathematics and operations research. With Gamma-Opt, I'm continuing the work related to my bachelor's thesis as well as the work of a few other bachelor's students. My main focus is the development of the [Gogeta.jl](https://github.com/gamma-opt/Gogeta.jl) package. This Julia package makes it possible to represent machine-learning models using mathematical programming.

--- a/content/authors/p_emilia-vuola/_index.md
+++ b/content/authors/p_emilia-vuola/_index.md
@@ -72,6 +72,7 @@ user_groups:
 - Research Assistants
 
 next_affiliation: Aalto University
+departure_year: 2020
 
 ---
 

--- a/content/authors/p_flavio-limapo/_index.md
+++ b/content/authors/p_flavio-limapo/_index.md
@@ -56,6 +56,7 @@ user_groups:
 - Previous Members
 
 next_affiliation: PUC-Rio
+departure_year: 2024
 ---
 
 Flávio Araújo Lim-Apo is a visiting researcher from Pontifical Catholic University of Rio de Janeiro (Brazil), where he is doing a PhD in the Operations Research area.

--- a/content/authors/p_fredrik-hagstrom/_index.md
+++ b/content/authors/p_fredrik-hagstrom/_index.md
@@ -73,6 +73,7 @@ user_groups:
 - Research Assistants
 
 next_affiliation: Aalto University
+departure_year: 2024
 
 
 ---

--- a/content/authors/p_hossein-mostafaei/_index.md
+++ b/content/authors/p_hossein-mostafaei/_index.md
@@ -75,6 +75,7 @@ user_groups:
 - Postdocs
 
 next_affiliation: Telia
+departure_date: 2021
 
 ---
 

--- a/content/authors/p_ilmari-vauhkonen/_index.md
+++ b/content/authors/p_ilmari-vauhkonen/_index.md
@@ -60,6 +60,7 @@ user_groups:
 - Research Assistants
 
 next_affiliation: Aalto University
+departure_year: 2020
 
 ---
 

--- a/content/authors/p_iuri-santos/_index.md
+++ b/content/authors/p_iuri-santos/_index.md
@@ -57,6 +57,7 @@ user_groups:
 - Previous Members
 
 next_affiliation: PUC-Rio
+departure_year: 2021
 ---
 
 Iuri Santos is a visiting researcher from Pontifical Catholic University of Rio de Janeiro (Brazil), where he is doing a PhD in the Operations Research area.

--- a/content/authors/p_jaan-tollander/_index.md
+++ b/content/authors/p_jaan-tollander/_index.md
@@ -61,6 +61,7 @@ user_groups:
 - Previous Members
 
 next_affiliation: Aalto University
+departure_year: 2020
 
 ---
 

--- a/content/authors/p_jiangyi-huang/_index.md
+++ b/content/authors/p_jiangyi-huang/_index.md
@@ -79,6 +79,7 @@ user_groups:
 - Doctoral Candidates
 
 next_affiliation: ETH
+departure_year: 2022 
 
 ---
 <div style="text-align: justify">

--- a/content/authors/p_juho-andelmin/_index.md
+++ b/content/authors/p_juho-andelmin/_index.md
@@ -85,6 +85,7 @@ user_groups:
 - Previous Members
 
 next_affiliation: Aalto University
+departure_year: 2023
 ---
 
 <div style="text-align: justify">

--- a/content/authors/p_julius-beranek/_index.md
+++ b/content/authors/p_julius-beranek/_index.md
@@ -55,6 +55,7 @@ user_groups:
 - Previous Members
 
 next_affiliation: Karlsruher Institut für Technologie - KIT 
+departure_year: 2021
 
 ---
 

--- a/content/authors/p_moritz-stinzendoerfer/_index.md
+++ b/content/authors/p_moritz-stinzendoerfer/_index.md
@@ -78,6 +78,7 @@ user_groups:
 - Previous Members
 
 next_affiliation: Technische Universität Kaiserslautern - RPTU
+departure_year: 2024
 ---
 
 Moritz Stinzendörfer is a Visiting Ph.D. Student at the Department of Mathematics and Systems Analysis, and working with Fabricio Oliveira and Philine Schwiewe at Aalto University. His research project is a stochastic optimization framework for multi-stage decision problems. He is interested in last-mile logistics, discrete optimization,transportation and urban planning.

--- a/content/authors/p_olli-herrala/_index.md
+++ b/content/authors/p_olli-herrala/_index.md
@@ -75,6 +75,7 @@ user_groups:
 - Previous Members
 
 next_affiliation: Aalto University
+departure_year: 2024
 
 ---
 

--- a/content/authors/p_pattanun-chanpiwat/_index.md
+++ b/content/authors/p_pattanun-chanpiwat/_index.md
@@ -63,6 +63,7 @@ user_groups:
 - Previous Members
 
 next_affiliation: Chulachomklao Royal Military Academy
+departure_year: 2023
 
 ---
 

--- a/content/authors/p_tarley_fantazzini/_index.md
+++ b/content/authors/p_tarley_fantazzini/_index.md
@@ -58,6 +58,7 @@ user_groups:
 - Past Members
 
 next_affiliation: Universidade Federal de São Carlos
+departure_year: 2024
 ---
 
 Tarley Mansur Fantazzini is a visiting researcher from Federal University of Sao Carlos (Brazil), where he is doing a PhD in the Operations Research area.

--- a/content/authors/p_victor-oei/_index.md
+++ b/content/authors/p_victor-oei/_index.md
@@ -71,6 +71,7 @@ user_groups:
 - Research Assistants
 
 next_affiliation: University of Stuttgart
+departure_year: 2022
 
 ---
 

--- a/content/authors/p_xinwei_lin/_index.md
+++ b/content/authors/p_xinwei_lin/_index.md
@@ -59,6 +59,8 @@ user_groups:
 - Visitor
 
 next_affiliation: Jiangnan University
+departure_year: 2023
+
 ---
 
 Xinwei Lin is a Visiting Ph.D. Student at the Department of Mathematics and Systems Analysis, and working with Prof. Fabricio Oliveira at Aalto University. His research project is cyclic scheduling optimization of ethylene cracking furnace system (ECFS) under uncertainty. He is interested in modeling for ECFS, decision making under uncertainty, robut optimization, and efficient strategies to solve large-scale problems.

--- a/layouts/partials/widgets/people.html
+++ b/layouts/partials/widgets/people.html
@@ -67,7 +67,8 @@
 <div style="margin-top: 30px;">
     <span style="font-size: 32px; margin-bottom: 6px; display: block;">Past Members:</span>
     <ul>
-        {{ range where (where site.Pages "Section" "authors") ".Params.user_groups" "intersect" (slice "Previous Members") }}
+        {{ $pms := where (where site.Pages "Section" "authors") ".Params.user_groups" "intersect" (slice "Previous Members") }}
+        {{ range sort $pms ".Params.departure_year" "desc" }}
         <li><strong>{{ .Title }}</strong>{{ if .Params.role }}: {{ .Params.role }} {{ end }} {{ if .Params.next_affiliation }} ({{ .Params.next_affiliation}}) {{ end }}</li>
         {{ end }}
     </ul>


### PR DESCRIPTION
Sorted in descending order so more recent people are at top (and those with no `departure_year`s are at the bottom). May be nice to add the year to the text as well.